### PR TITLE
Change request from http to https

### DIFF
--- a/lib/chilexpress.rb
+++ b/lib/chilexpress.rb
@@ -17,7 +17,7 @@ module Chilexpress
   end
 
   def self.get_document(order_number)
-    Nokogiri::HTML(open("http://www.chilexpress.cl/Views/ChilexpressCL/Resultado-busqueda.aspx?DATA=#{order_number}"))
+    Nokogiri::HTML(open("https://www.chilexpress.cl/Views/ChilexpressCL/Resultado-busqueda.aspx?DATA=#{order_number}"))
   end
 
   def self.document_has_valid_order?(document)


### PR DESCRIPTION
Actually chilexpress change their http protocol at tracking page and
redirect to https.
It produces a fall of nokogiri and raise an error